### PR TITLE
design : nav바 접기 자연스럽게

### DIFF
--- a/public/css/navigation.css
+++ b/public/css/navigation.css
@@ -26,3 +26,12 @@ button#write{
   background: var(--bg-gray);
   &:hover{background:var(--bg-hover)}
 }
+
+#navi{
+  transition: all .6s ease-in-out;
+}
+#navi.slidedown{
+  margin-left: -100%;
+}
+#nav-expand{transition: all .3s ease-in-out;}
+#nav-expand.hide{opacity: 0; cursor:default;}

--- a/public/js/event.js
+++ b/public/js/event.js
@@ -96,7 +96,7 @@ function handleBlockquote (content,prev) {
 
 function navCollapse() {
   const navi = document.getElementById("navi");
-  navi.classList.add("d-none");
+  navi.classList.add("slidedown");
 
   let navExpand = document.getElementById("nav-expand");
   if(!navExpand){
@@ -108,13 +108,15 @@ function navCollapse() {
     content.innerHTML += navExpandHTML;
   }
   navExpand = document.getElementById("nav-expand");
-  navExpand.classList.remove("d-none");
+  navExpand.classList.remove("hide");
+  navExpand.disable=false;
 }
 function navExpand() {
   const navi = document.getElementById("navi");
-  navi.classList.remove("d-none");
+  navi.classList.remove("slidedown");
   const navExpand = document.getElementById("nav-expand");
-  navExpand.classList.add("d-none");
+  navExpand.classList.add("hide");
+  navExpand.disable=true;
 }
 
 function changeTitle(e) {

--- a/public/js/mainHeader.js
+++ b/public/js/mainHeader.js
@@ -6,7 +6,7 @@ async function render(data){
   return `
   <!-- top menu -->
   <div id="mainHeader" class="container-fluid align-items-center d-flex">
-    <button id="nav-expand" class="btn btn-outline-light text-black d-block rounded border-0 d-none" style="font-size: small;">
+    <button id="nav-expand" class="btn btn-outline-light text-black d-block rounded border-0 hide" style="font-size: small;" disable="disable">
       <i class="fa-solid fa-angles-left" style="color: #4f4f4f; pointer-events:none; transform:scaleX(-1);"></i>
     </button>
     ${_breadcrumb}

--- a/public/js/navi.js
+++ b/public/js/navi.js
@@ -68,7 +68,7 @@ async function render(path, query) {
               <span class="fs-5 fw-semibold text-break">${response.config.headers["x-username"]}의 노션</span>
             </div>
           <button id="close" class="btn text-black d-block rounded border-sm pe-0 py-1">
-                <i class="fa-solid fa-angles-left" style="color: #4f4f4f; pointer-events:none"></i>
+                <i class="fa-solid fa-angles-left" style="color: #4f4f4f; pointer-events:none; font-size:small;"></i>
           </button>
         </div>
         <hr>


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
navi 접을 때 좀 더 자연스럽게 수정

### 💻 상세 내용(Describe your changes)
- 기존 display:none; 속성은 애니메이션이 안먹어서 클래스 변경 및 애니메이션 추가
- nav접었다 폈을 때 열기 버튼이 사라지며 헤더가 좌측으로 이동함 -> 열기 버튼의 경우 header에 포함시키지 않고 좌측 영역을 잡은 후 거기에 얹는게 자연스러워 보이겠지만...임시 방편으로 열려있을 때 disable 및 opacity 처리 했습니다.

### 📌 관련 이슈번호(Related Issue)