### PR TITLE
fix : content 불러오는 과정에 태그에서 잘리는 문제 해결, 레이아웃 일부 수정

### DIFF
--- a/public/css/welcome.css
+++ b/public/css/welcome.css
@@ -11,8 +11,12 @@
 #welcomeContents div.list *{
     pointer-events:none;
 }
-#welcomeContents .list p {
+#welcomeContents .d-grid{
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+#welcomeContents .list :where(p,blockquote) {
     width: 100%;
+    height: 2.5rem;
     text-overflow: ellipsis;
     overflow: hidden;
     word-break: break-word;

--- a/public/js/welcome.js
+++ b/public/js/welcome.js
@@ -59,13 +59,13 @@ async function render(path, query){
         <h2 class="fw-semibold text-center mb-4">${userName}님, 안녕하세요.</h2>
         <div class="my-4">
           <p class="fs-6"><i class="bi bi-clock-history fs-6"></i> <span class="ms-1">최근 파일</span></p>
-          <div class="d-flex gap-2">
+          <div class="d-grid gap-2">
           ${
             latestDocs.map((doc, idx)=>{
               return `
               <div class="list border rounded-2 p-3 col" data-id="${doc.id}">
                   <h6 class="text-truncate">${doc.title}</h6>
-                  <blockquote class="mb-1 fs-6 fw-light lh-sm">${doc.content.slice(0, 20).trim()}</blockquote>
+                  <blockquote class="mb-1 fs-6 fw-light lh-sm">${doc.content.replace(/<[^>]+>/g,"").slice(0,500)}</blockquote>
                   <span class="updated">${updateTimeCalc(doc.updatedAt)}</span>
               </div>`
             }).join("")


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
content 불러오는 과정에 태그에서 잘리는 문제 해결, 레이아웃 일부 수정

### 💻 상세 내용(Describe your changes)
- content 읽어오는 과정에 태그까지 가지고 와서 20char 잘라서 DOM에 덧씌워지는 문제 해결
- 요약본 보여주는 거니 태그 삭제 후 pure content만 불러오게 함
- slice 안하면 문서 길어질 때 낭비일 거 같아 적당히 500자 정도에서 자르게 변경
- 내부 콘텐츠에 따라 flex 내부 items들 가로 사이즈 바뀌는 문제 해결 (grid로 변경)
- 콘텐츠 창 화면 작아져도 대응하도록 수정

### 📌 관련 이슈번호(Related Issue)